### PR TITLE
fix when expected input contains line break

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@
 *.iml
 /**/gen
 /pom.xml.versionsBackup
+
+/nbproject/

--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,19 @@
 			<artifactId>maven-plugin-testing-harness</artifactId>
 			<version>3.3.0</version>
 			<scope>test</scope>
+                        <exclusions>
+                            <exclusion>
+                                <groupId>junit</groupId>
+                                <artifactId>junit</artifactId>
+                            </exclusion>
+                         </exclusions>
 		</dependency>
+                	<dependency>
+                    <groupId>junit</groupId>
+                    <artifactId>junit</artifactId>
+                    <version>4.12</version>
+                    <scope>test</scope>
+                </dependency>
 		<dependency>
 			<groupId>org.apache.maven</groupId>
 			<artifactId>maven-core</artifactId>
@@ -171,6 +183,19 @@
 					</execution>
 				</executions>
 			</plugin>
+                        <plugin>
+                            <groupId>org.jacoco</groupId>
+                            <artifactId>jacoco-maven-plugin</artifactId>
+                            <version>0.7.9</version>
+                            <executions>
+                                <execution>
+                                    <id>prepare-agent</id>
+                                    <goals>
+                                        <goal>prepare-agent</goal>
+                                    </goals>
+                                </execution>
+                            </executions>
+                      </plugin>
 		</plugins>
 		<finalName>${project.artifactId}-${project.version}</finalName>
 	</build>

--- a/src/main/java/com/khubla/antlr/antlr4test/AntlrCaseInsensitiveFileStream.java
+++ b/src/main/java/com/khubla/antlr/antlr4test/AntlrCaseInsensitiveFileStream.java
@@ -1,3 +1,30 @@
+/*
+ [The "BSD license"]
+ Copyright (c) 2014 Tom Everett
+ All rights reserved.
+
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions
+ are met:
+ 1. Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+ 2. Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in the
+    documentation and/or other materials provided with the distribution.
+ 3. The name of the author may not be used to endorse or promote products
+    derived from this software without specific prior written permission.
+
+ THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+ IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+ INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
 package com.khubla.antlr.antlr4test;
 
 import java.io.IOException;

--- a/src/main/java/com/khubla/antlr/antlr4test/AssertErrorsErrorListener.java
+++ b/src/main/java/com/khubla/antlr/antlr4test/AssertErrorsErrorListener.java
@@ -19,31 +19,20 @@ public class AssertErrorsErrorListener extends BaseErrorListener {
    protected static final String LITERAL_BACKSLASH_R = "\\\\r";
    protected static final String LITERAL_BACKSLASH_N_PLACEHOLDER = "literal-backslash-n";
    protected static final String LITERAL_BACKSLASH_N = "\\\\n";
-   protected List<String> errorMessages = new ArrayList<String>();
+   protected List<String> errorMessages = new ArrayList<>();
 
    public void assertErrors(File errorMessagesFile, String encoding) throws AssertErrorsException {
       if (!errorMessages.isEmpty()) {
          List<String> expectedErrorMessages = null;
+         String errorMessageFileName = errorMessagesFile.getName();
          try {
             expectedErrorMessages = FileUtil.getNonEmptyLines(errorMessagesFile, encoding);
          } catch (final FileNotFoundException ex) {
-            throw new AssertErrorsException(String.format("found %d errors, but missing file %s", errorMessages.size(), errorMessagesFile.getName()), ex);
+            throw new AssertErrorsException(String.format("found %d errors, but missing file %s", errorMessages.size(), errorMessageFileName), ex);
          } catch (final IOException ex) {
-            throw new AssertErrorsException(String.format("found %d errors, unable to read file %s", errorMessages.size(), errorMessagesFile.getName()), ex);
+            throw new AssertErrorsException(String.format("found %d errors, unable to read file %s", errorMessages.size(), errorMessageFileName), ex);
          }
-         expectedErrorMessages = replacePlaceholders(expectedErrorMessages);
-         final Object[] expectedErrors = expectedErrorMessages.toArray();
-         final Object[] errors = errorMessages.toArray();
-         if (expectedErrors.length != errors.length) {
-            throw new AssertErrorsException(String.format("%s : expected %d errors, but was %d errors", errorMessagesFile.getName(), expectedErrors.length, errors.length));
-         }
-         for (int i = 0; i < expectedErrors.length; i = i + 1) {
-            final Object expectedError = expectedErrors[i];
-            final Object error = errors[i];
-            if (!expectedError.equals(error)) {
-               throw new AssertErrorsException(String.format("%s : expected (%s), but was (%s)", errorMessagesFile.getName(), expectedError, error));
-            }
-         }
+         asserts(expectedErrorMessages, errorMessageFileName);
       } else {
          if (errorMessagesFile.exists()) {
             throw new AssertErrorsException(String.format("no errors found, but errors file exists %s", errorMessagesFile.getAbsolutePath()));
@@ -51,8 +40,25 @@ public class AssertErrorsErrorListener extends BaseErrorListener {
       }
    }
 
+    void asserts(List<String> expectedErrorMessages, String errorMessageFileName) throws AssertErrorsException {
+        List<String> expectedErrors = replacePlaceholders(expectedErrorMessages);
+        List<String> actualErrors = replacePlaceholders(errorMessages);
+        int expectedSize = expectedErrors.size();
+        int actualSize = actualErrors.size();
+        if (expectedSize != actualSize) {
+            throw new AssertErrorsException(String.format("%s : expected %d errors, but was %d errors", errorMessageFileName, expectedSize, actualSize));
+        }
+        for (int i = 0; i < expectedSize; i++) {
+            final String expectedError = expectedErrors.get(i);
+            final String error = actualErrors.get(i);
+            if (!expectedError.equals(error)) {
+                throw new AssertErrorsException(String.format("%s : expected (%s), but was (%s)", errorMessageFileName, expectedError, error));
+            }
+        }
+    }
+
    protected List<String> replacePlaceholders(List<String> stringList) {
-      final List<String> replacedStringList = new ArrayList<String>();
+      final List<String> replacedStringList = new ArrayList<>();
       for (final String vString : stringList) {
          replacedStringList.add(replacePlaceholders(vString));
       }

--- a/src/main/java/com/khubla/antlr/antlr4test/AssertErrorsErrorListener.java
+++ b/src/main/java/com/khubla/antlr/antlr4test/AssertErrorsErrorListener.java
@@ -1,3 +1,30 @@
+/*
+ [The "BSD license"]
+ Copyright (c) 2014 Tom Everett
+ All rights reserved.
+
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions
+ are met:
+ 1. Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+ 2. Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in the
+    documentation and/or other materials provided with the distribution.
+ 3. The name of the author may not be used to endorse or promote products
+    derived from this software without specific prior written permission.
+
+ THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+ IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+ INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
 package com.khubla.antlr.antlr4test;
 
 import java.io.File;

--- a/src/main/java/com/khubla/antlr/antlr4test/AssertErrorsException.java
+++ b/src/main/java/com/khubla/antlr/antlr4test/AssertErrorsException.java
@@ -1,3 +1,30 @@
+/*
+ [The "BSD license"]
+ Copyright (c) 2014 Tom Everett
+ All rights reserved.
+
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions
+ are met:
+ 1. Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+ 2. Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in the
+    documentation and/or other materials provided with the distribution.
+ 3. The name of the author may not be used to endorse or promote products
+    derived from this software without specific prior written permission.
+
+ THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+ IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+ INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
 package com.khubla.antlr.antlr4test;
 
 public class AssertErrorsException extends Exception {

--- a/src/main/java/com/khubla/antlr/antlr4test/CaseInsensitiveType.java
+++ b/src/main/java/com/khubla/antlr/antlr4test/CaseInsensitiveType.java
@@ -1,3 +1,30 @@
+/*
+ [The "BSD license"]
+ Copyright (c) 2014 Tom Everett
+ All rights reserved.
+
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions
+ are met:
+ 1. Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+ 2. Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in the
+    documentation and/or other materials provided with the distribution.
+ 3. The name of the author may not be used to endorse or promote products
+    derived from this software without specific prior written permission.
+
+ THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+ IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+ INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
 package com.khubla.antlr.antlr4test;
 
 enum CaseInsensitiveType {

--- a/src/test/java/com/khubla/antlr/antlr4test/AssertErrorsErrorListenerTest.java
+++ b/src/test/java/com/khubla/antlr/antlr4test/AssertErrorsErrorListenerTest.java
@@ -3,11 +3,8 @@
  */
 package com.khubla.antlr.antlr4test;
 
-import java.io.File;
 import java.util.Collections;
 import java.util.List;
-import org.antlr.v4.runtime.RecognitionException;
-import org.antlr.v4.runtime.Recognizer;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -38,7 +35,7 @@ public class AssertErrorsErrorListenerTest {
     }
     
     /**
-     * Test of replacePlaceholders method, of class AssertErrorsErrorListener.
+     * Test of asserts method, of class AssertErrorsErrorListener.
      */
     @Test
     public void testAssertErrors_Matching() throws AssertErrorsException {

--- a/src/test/java/com/khubla/antlr/antlr4test/AssertErrorsErrorListenerTest.java
+++ b/src/test/java/com/khubla/antlr/antlr4test/AssertErrorsErrorListenerTest.java
@@ -1,5 +1,29 @@
 /*
- * 
+ [The "BSD license"]
+ Copyright (c) 2014 Tom Everett
+ All rights reserved.
+
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions
+ are met:
+ 1. Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+ 2. Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in the
+    documentation and/or other materials provided with the distribution.
+ 3. The name of the author may not be used to endorse or promote products
+    derived from this software without specific prior written permission.
+
+ THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+ IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+ INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 package com.khubla.antlr.antlr4test;
 

--- a/src/test/java/com/khubla/antlr/antlr4test/AssertErrorsErrorListenerTest.java
+++ b/src/test/java/com/khubla/antlr/antlr4test/AssertErrorsErrorListenerTest.java
@@ -1,0 +1,54 @@
+/*
+ * 
+ */
+package com.khubla.antlr.antlr4test;
+
+import java.io.File;
+import java.util.Collections;
+import java.util.List;
+import org.antlr.v4.runtime.RecognitionException;
+import org.antlr.v4.runtime.Recognizer;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+/**
+ *
+ * @author mario.schroeder
+ */
+public class AssertErrorsErrorListenerTest {
+    
+    private AssertErrorsErrorListener classUnderTest;
+    
+    @Before
+    public void setUp() {
+        classUnderTest = new AssertErrorsErrorListener();
+    }
+
+    /**
+     * Test of replacePlaceholders method, of class AssertErrorsErrorListener.
+     */
+    @Test
+    public void testReplacePlaceholders_Unchanged() {
+        String line = "mismatched input '\\n' expecting 'foo'";
+        List<String> lines = Collections.singletonList(line);
+        classUnderTest.replacePlaceholders(lines);
+        assertEquals(lines.get(0), line);
+    }
+    
+    /**
+     * Test of replacePlaceholders method, of class AssertErrorsErrorListener.
+     */
+    @Test
+    public void testAssertErrors_Matching() throws AssertErrorsException {
+        String line = "mismatched input '\\n' expecting 'foo'";
+        classUnderTest.syntaxError(null, null, 1, 7, line, null);
+        
+        String expected = "line 1:7 "+line;
+        List<String> lines = Collections.singletonList(expected);
+        classUnderTest.asserts(lines, getClass().getSimpleName());
+        assertEquals(lines.get(0), expected);
+    }
+    
+}


### PR DESCRIPTION
This PR will fix the phenomenom when there is a line break in the error file.

Assume you have an error file with this content:
line 1:29 mismatched input '\n' expecting 'namespace'

The class AssertErrorsErrorListener was replacing that line but not the actual error message. Therefore you get a mismatch like this:

com.khubla.antlr.antlr4test.AssertErrorsException: namespace.cto.errors : expected (line 1:29 mismatched input '
' expecting 'namespace'), but was (line 1:29 mismatched input '\n' expecting 'namespace')

The change will replace the place holders of the expecting message too.