### PR TITLE
- Solve issues #9 and #23.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,6 +40,7 @@
 	<properties>
 		<maven.version>3.6.0</maven.version>
 		<antlr.version>4.8-1</antlr.version>
+		<org.easymock.version>3.6</org.easymock.version>
 	</properties>
 	<dependencies>
 		<dependency>
@@ -110,6 +111,12 @@
 			<groupId>org.bitbucket.cowwoc</groupId>
 			<artifactId>diff-match-patch</artifactId>
 			<version>1.2</version>
+		</dependency>
+		<dependency>
+			<groupId>org.easymock</groupId>
+			<artifactId>easymock</artifactId>
+			<version>${org.easymock.version}</version>
+			<scope>test</scope>
 		</dependency>
 	</dependencies>
 	<build>

--- a/src/main/java/com/khubla/antlr/antlr4test/ScenarioExecutor.java
+++ b/src/main/java/com/khubla/antlr/antlr4test/ScenarioExecutor.java
@@ -142,7 +142,7 @@ public class ScenarioExecutor {
 		/*
 		 * build lexer
 		 */
-		final AssertErrorsErrorListener assertErrorsErrorListener = new AssertErrorsErrorListener();
+		final AssertErrorsErrorListener assertErrorsErrorListener = new AssertErrorsErrorListener(this.scenario, this.log);
 		Lexer lexer = (Lexer) lexerConstructor.newInstance(antlrFileStream);
 		lexer.addErrorListener(assertErrorsErrorListener);
 		/*

--- a/src/test/java/com/khubla/antlr/antlr4test/AssertErrorsErrorListenerTest.java
+++ b/src/test/java/com/khubla/antlr/antlr4test/AssertErrorsErrorListenerTest.java
@@ -27,12 +27,18 @@
  */
 package com.khubla.antlr.antlr4test;
 
+import java.io.File;
 import java.util.Collections;
 import java.util.List;
+
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
 import static org.junit.Assert.*;
+import static org.easymock.EasyMock.*;
+
+import org.apache.maven.plugin.logging.Log;
 
 /**
  *
@@ -40,11 +46,22 @@ import static org.junit.Assert.*;
  */
 public class AssertErrorsErrorListenerTest {
     
-    private AssertErrorsErrorListener classUnderTest;
+    private Scenario scenario = null;
+    private Log log = null;
+    private AssertErrorsErrorListener classUnderTest = null;
+    
+    @After
+    public void tearDown() {
+        this.scenario = null;
+        this.log = null;
+        this.classUnderTest = null;
+    }
     
     @Before
     public void setUp() {
-        classUnderTest = new AssertErrorsErrorListener();
+        this.scenario = mock(Scenario.class);
+        this.log = mock(Log.class);
+        classUnderTest = new AssertErrorsErrorListener(scenario, log);
     }
 
     /**
@@ -52,6 +69,8 @@ public class AssertErrorsErrorListenerTest {
      */
     @Test
     public void testReplacePlaceholders_Unchanged() {
+        replay(this.scenario);
+        replay(this.log);
         String line = "mismatched input '\\n' expecting 'foo'";
         List<String> lines = Collections.singletonList(line);
         classUnderTest.replacePlaceholders(lines);
@@ -63,6 +82,9 @@ public class AssertErrorsErrorListenerTest {
      */
     @Test
     public void testAssertErrors_Matching() throws AssertErrorsException {
+        expect(this.scenario.isVerbose()).andReturn(false).times(1);
+        replay(this.scenario);
+        replay(this.log);
         String line = "mismatched input '\\n' expecting 'foo'";
         classUnderTest.syntaxError(null, null, 1, 7, line, null);
         
@@ -72,4 +94,196 @@ public class AssertErrorsErrorListenerTest {
         assertEquals(lines.get(0), expected);
     }
     
+    /**
+     * Test of assertErrors method with empty file and an error.
+     */
+    @Test
+    public void testAssertErrors_EmptyFile_Errors() {
+        expect(this.scenario.isVerbose()).andReturn(false).times(1);
+        replay(this.scenario);
+        replay(this.log);
+        File errorMessagesFile = new File ( ClassLoader.getSystemResource( "./SampleErrorsEmptyFile.errors").getFile() );
+        String line = "mismatched input '\\n' expecting 'foo'";
+        classUnderTest.syntaxError(null, null, 1, 7, line, null);
+        try
+        {
+            classUnderTest.assertErrors( errorMessagesFile, "UTF-8" );
+            fail("Expected exception AssertErrorsException does not thrown");
+        }
+        catch ( AssertErrorsException e )
+        {
+            assertEquals("SampleErrorsEmptyFile.errors : expected 0 errors, but was 1 errors", e.getMessage());
+        }        
+    }
+    
+    /**
+     * Test of assertErrors method with empty file and no errors.
+     */
+    @Test
+    public void testAssertErrors_EmptyFile_NoErrors() {
+        replay(this.scenario);
+        replay(this.log);
+        File errorMessagesFile = new File ( ClassLoader.getSystemResource( "./SampleErrorsEmptyFile.errors").getFile() );
+        try
+        {
+            classUnderTest.assertErrors( errorMessagesFile, "UTF-8" );
+            fail("Expected exception AssertErrorsException does not thrown");
+        }
+        catch ( AssertErrorsException e )
+        {
+            assertTrue(e.getMessage().startsWith( "no errors found, but errors file exists" ));
+            assertTrue(e.getMessage().endsWith( "SampleErrorsEmptyFile.errors" ));
+        }        
+    }
+    
+    /**
+     * Test of assertErrors method with non existing file and no errors.
+     */
+    @Test
+    public void testAssertErrors_NonExistingFile_NoErrors() {
+        replay(this.scenario);
+        replay(this.log);
+        File errorMessagesFile = null;
+        try
+        {
+            classUnderTest.assertErrors( errorMessagesFile, "UTF-8" );
+        }
+        catch ( Exception e )
+        {
+            e.printStackTrace();
+            fail("Unexpected exception thrown: " + e.getMessage());
+        }        
+    }
+    
+    /**
+     * Test of assertErrors method with non existing file and no errors.
+     */
+    @Test
+    public void testAssertErrors_NullFile_Errors() {
+        expect(this.scenario.isVerbose()).andReturn(false).times(1);
+        replay(this.scenario);
+        replay(this.log);
+        File errorMessagesFile = null;
+        String line = "mismatched input '\\n' expecting 'foo'";
+        classUnderTest.syntaxError(null, null, 1, 7, line, null);
+        try
+        {
+            classUnderTest.assertErrors( errorMessagesFile, "UTF-8" );
+            fail("Expected exception AssertErrorsException does not thrown");
+        }
+        catch ( NullPointerException e )
+        {
+            assertNull(e.getMessage());
+        }
+        catch ( Exception e )
+        {
+            fail("Unexpected exception thrown: " + e.getMessage());
+        }        
+    }
+    
+    /**
+     * Test of assertErrors method with non existing file and no errors.
+     */
+    @Test
+    public void testAssertErrors_NonExistingFile_Errors() {
+        expect(this.scenario.isVerbose()).andReturn(false).times(1);
+        replay(this.scenario);
+        replay(this.log);
+        File errorMessagesFile = new File("Foo.bar");
+        String line = "mismatched input '\\n' expecting 'foo'";
+        classUnderTest.syntaxError(null, null, 1, 7, line, null);
+        try
+        {
+            classUnderTest.assertErrors( errorMessagesFile, "UTF-8" );
+            fail("Expected exception AssertErrorsException does not thrown");
+        }
+        catch ( AssertErrorsException e )
+        {
+            assertEquals("found 1 errors, but missing file Foo.bar", e.getMessage());
+        }        
+        catch ( Exception e )
+        {
+            fail("Unexpected exception thrown: " + e.getMessage());
+        }        
+    }
+    
+    /**
+     * Test of assertErrors method with non existing file and no errors.
+     */
+    @Test
+    public void testAssertErrors_Mismatching_Errors() {
+        expect(this.scenario.isVerbose()).andReturn(false).times(2);
+        replay(this.scenario);
+        replay(this.log);
+        File errorMessagesFile = new File ( ClassLoader.getSystemResource( "./SampleErrorsFileNonEmpty.errors").getFile() );
+        String line = "mismatched input '\\n' expecting 'foo'";
+        classUnderTest.syntaxError(null, null, 1, 7, line, null);
+        classUnderTest.syntaxError(null, null, 13, 5, line, null);
+        try
+        {
+            classUnderTest.assertErrors( errorMessagesFile, "UTF-8" );
+            fail("Expected exception AssertErrorsException does not thrown");
+        }
+        catch ( NullPointerException e )
+        {
+            assertNull(e.getMessage());
+        }
+        catch ( AssertErrorsException e )
+        {
+            assertEquals("SampleErrorsFileNonEmpty.errors : expected (line 2:8 mismatched input '\n" + 
+                "' expecting 'foo'), but was (line 13:5 mismatched input '\n" + 
+                "' expecting 'foo')", e.getMessage());
+        }        
+        catch ( Exception e )
+        {
+            fail("Unexpected exception thrown: " + e.getMessage());
+        }        
+    }
+
+    /**
+     * Test of assertErrors method with non existing file and no errors.
+     */
+    @Test
+    public void testAssertErrors_Matching_Errors() {
+        expect(this.scenario.isVerbose()).andReturn(false).times(2);
+        replay(this.scenario);
+        replay(this.log);
+        File errorMessagesFile = new File ( ClassLoader.getSystemResource( "./SampleErrorsFileNonEmpty.errors").getFile() );
+        String line = "mismatched input '\\n' expecting 'foo'";
+        classUnderTest.syntaxError(null, null, 1, 7, line, null);
+        classUnderTest.syntaxError(null, null, 2, 8, line, null);
+        try
+        {
+            classUnderTest.assertErrors( errorMessagesFile, "UTF-8" );
+        }
+        catch ( Exception e )
+        {
+            fail("Unexpected exception thrown: " + e.getMessage());
+        }        
+    }
+    /**
+     * Test of assertErrors method with non existing file and no errors.
+     */
+    @Test
+    public void testAssertLog() {
+        File errorMessagesFile = new File ( ClassLoader.getSystemResource( "./SampleErrorsFileNonEmpty.errors").getFile() );
+        String line = "mismatched input '\\n' expecting 'foo'";
+        expect(this.scenario.isVerbose()).andReturn(true).times(2);
+        this.log.warn("line 1:7 mismatched input '\\n' expecting 'foo'");
+        expectLastCall().times(1);
+        this.log.warn("line 2:8 mismatched input '\\n' expecting 'foo'");
+        expectLastCall().times(1);
+        replay(this.scenario);
+        replay(this.log);
+        classUnderTest.syntaxError(null, null, 1, 7, line, null);
+        classUnderTest.syntaxError(null, null, 2, 8, line, null);
+        try
+        {
+            classUnderTest.assertErrors( errorMessagesFile, "UTF-8" );
+        }
+        catch ( Exception e )
+        {
+            fail("Unexpected exception thrown: " + e.getMessage());
+        }        
+    }
 }

--- a/src/test/resources/SampleErrorsFileNonEmpty.errors
+++ b/src/test/resources/SampleErrorsFileNonEmpty.errors
@@ -1,0 +1,2 @@
+line 1:7 mismatched input '\n' expecting 'foo'
+line 2:8 mismatched input '\n' expecting 'foo'


### PR DESCRIPTION
This PR adds capability of showing parsing errors through maven log output when verbose option is true, solving issue #23 .

It also adds basic documentation about .errors and .tree files, solving issue #9 .

Finally, unit tests on AssertErrorsErrorListener class are improved by checking conditions with .errors files and by adding easymock 3.6 to support those checks. Easymock 4.2 was also tried, but due to java version incompatibilities and no advanced testing features necessity, the downgrade was made.