### PR TITLE
Add missing parameter annotation

### DIFF
--- a/src/main/java/com/khubla/antlr/antlr4test/GrammarTestMojo.java
+++ b/src/main/java/com/khubla/antlr/antlr4test/GrammarTestMojo.java
@@ -97,6 +97,7 @@ public class GrammarTestMojo extends AbstractMojo {
 	/**
 	 * testFileExtension
 	 */
+	@Parameter
 	private String testFileExtension = null;
 	/**
 	 * basedir dir


### PR DESCRIPTION
The missing annotation somehow causes ```testFileExtension``` in [algol60](https://github.com/antlr/grammars-v4/blob/master/algol60/pom.xml) and [cto](https://github.com/antlr/grammars-v4/blob/master/cto/pom.xml) not to work.